### PR TITLE
Adding Object#const_get support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.3.0 (September 1st, 2020)
+
+Additions:
+
+* Added dynamic class constantization when a string is registered for a Factory.
+
 # 1.2.0 (June 9th, 2020)
 
 * Bumped minimum Ruby version to >= 2.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.3.0 (September 1st, 2020)
+# 1.3.0 (September 5th, 2020)
 
 Additions:
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,21 @@ end
 
 In case you need full control of the registry you can also choose to simply override the class-level `registry` method which will simply return a hash of keys (names) and values (class constants).
 
+### Resolving Constants at Runtime
+
+Factories can also be resolved using Ruby's Object#const_get and Object#const_missing.  Simply register a string  representing the class in order to use these mechanics, such as:
+
+```ruby
+class ExampleFactory
+  acts_as_hashable_factory
+
+  type_key 'object_type'
+
+  register 'Pet', 'Pet'
+
+  register 'HeadOfHousehold', ->(_key) { HeadOfHousehold }
+end
+
 ## Contributing
 
 ### Development Environment Configuration

--- a/lib/acts_as_hashable/constant_resolver.rb
+++ b/lib/acts_as_hashable/constant_resolver.rb
@@ -10,7 +10,7 @@
 module ActsAsHashable
   # This class is responsible for turning strings and symbols into constants.
   # It does not deal with inflection, simply just constant resolution.
-  class ConstantResolver
+  class ConstantResolver # :nodoc: all
     # Only use Module constant resolution if a string or symbol was passed in.
     # Any other type is defined as an acceptable constant and is simply returned.
     def constantize(value)

--- a/lib/acts_as_hashable/constant_resolver.rb
+++ b/lib/acts_as_hashable/constant_resolver.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2019-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+module ActsAsHashable
+  # This class is responsible for turning strings and symbols into constants.
+  # It does not deal with inflection, simply just constant resolution.
+  class ConstantResolver
+    # Only use Module constant resolution if a string or symbol was passed in.
+    # Any other type is defined as an acceptable constant and is simply returned.
+    def constantize(value)
+      value.is_a?(String) || value.is_a?(Symbol) ? object_constant(value) : value
+    end
+
+    private
+
+    # If the constant has been loaded, we can safely use it through const_get.
+    # If the constant has not been loaded, we need to defer to const_missing to resolve it.
+    # If we blindly call const_get, it may return false positives for namespaced constants
+    # or anything nested.
+    def object_constant(value)
+      if Object.const_defined?(value, false)
+        Object.const_get(value, false)
+      else
+        Object.const_missing(value)
+      end
+    end
+  end
+end

--- a/lib/acts_as_hashable/factory.rb
+++ b/lib/acts_as_hashable/factory.rb
@@ -38,22 +38,22 @@ module ActsAsHashable
       end
     end
 
-    def registry
+    def registry # :nodoc:
       @registry ||= {}
     end
 
-    def materialize_registry
+    def materialize_registry # :nodoc:
       @registry.map do |k, v|
         value = v.is_a?(Proc) ? v.call(k) : v
         [k, value]
       end.to_h
     end
 
-    def type_key(key)
+    def type_key(key) # :nodoc:
       @typed_with = key
     end
 
-    def typed_with
+    def typed_with # :nodoc:
       @typed_with || TypeFactory::DEFAULT_TYPE_KEY
     end
 

--- a/lib/acts_as_hashable/hash_refinements.rb
+++ b/lib/acts_as_hashable/hash_refinements.rb
@@ -10,7 +10,7 @@
 module ActsAsHashable
   # Let's provide a refinenment instead of monkey-patching Hash.  That way we can stop
   # polluting other libraries and internalize our specific needs.
-  module HashRefinements
+  module HashRefinements # :nodoc: all
     refine Hash do
       def symbolize_keys
         map { |k, v| [k.to_sym, v] }.to_h

--- a/lib/acts_as_hashable/version.rb
+++ b/lib/acts_as_hashable/version.rb
@@ -8,5 +8,5 @@
 #
 
 module ActsAsHashable
-  VERSION = '1.2.0'
+  VERSION = '1.3.0-alpha'
 end

--- a/lib/acts_as_hashable/version.rb
+++ b/lib/acts_as_hashable/version.rb
@@ -8,5 +8,5 @@
 #
 
 module ActsAsHashable
-  VERSION = '1.3.0-alpha'
+  VERSION = '1.3.0'
 end

--- a/spec/constant_resolver_spec.rb
+++ b/spec/constant_resolver_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2019-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require 'spec_helper'
+
+describe ActsAsHashable::ConstantResolver do
+  module A
+    class B; end
+    class E; end
+  end
+
+  class B; end
+
+  module C
+    class D; end
+    class E; end
+
+    module F
+      class G; end
+    end
+  end
+
+  it 'resolves nested constant with the same as an ancestor constants sibling' do
+    expect(subject.constantize('A::B')).to eq(::A::B)
+  end
+
+  it 'resolves root constant' do
+    expect(subject.constantize('B')).to eq(::B)
+  end
+
+  it 'does not resolve constant in a different parent module' do
+    expect { subject.constantize('C::B') }.to raise_error(NameError)
+  end
+
+  it 'does not resolve constant in a different parent module' do
+    expect { subject.constantize('D') }.to raise_error(NameError)
+  end
+
+  it 'resolves same leaf constants specific to their parents' do
+    expect(subject.constantize('A::E')).to eq(::A::E)
+    expect(subject.constantize('C::E')).to eq(::C::E)
+  end
+
+  it 'does not resolve constant without its parent' do
+    expect { subject.constantize('F') }.to raise_error(NameError)
+  end
+end

--- a/spec/examples.rb
+++ b/spec/examples.rb
@@ -72,7 +72,7 @@ class ExampleFactory
 
   register 'Person', Person
   register 'Pet', Pet
-  register 'Toy', Toy
+  register 'Toy', 'Toy' # test out string constantization
   register 'class_with_no_arguments', ClassWithNoArguments
 
   # These are examples of registering a proc instead of a class constant.  It

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -12,44 +12,58 @@ require './spec/spec_helper'
 describe ActsAsHashable::Factory do
   subject { ExampleFactory }
 
-  context 'when hydrating classes argument-less constructors' do
-    it 'calls constructor with no arguments' do
-      expect { ExampleFactory.make(object_type: :class_with_no_arguments) }.not_to raise_error
+  describe '#make' do
+    context 'when registered object is a string' do
+      it 'does not raise error' do
+        expect { ExampleFactory.make(object_type: 'Toy') }.not_to raise_error
+      end
+
+      it 'instantiates correct class' do
+        toy = ExampleFactory.make(object_type: 'Toy')
+
+        expect(toy).to be_a(Toy)
+      end
     end
-  end
 
-  it 'should hydrate example objects' do
-    objects = [
-      {
-        object_type: 'Pet',
-        name: 'Doug the dog',
-        toy: { squishy: true }
-      },
-      {
-        object_type: 'HeadOfHousehold',
-        person: {
-          name: 'Matt',
-          age: 109
+    context 'when hydrating classes argument-less constructors' do
+      it 'calls constructor with no arguments' do
+        expect { ExampleFactory.make(object_type: :class_with_no_arguments) }.not_to raise_error
+      end
+    end
+
+    it 'should hydrate example objects' do
+      objects = [
+        {
+          object_type: 'Pet',
+          name: 'Doug the dog',
+          toy: { squishy: true }
         },
-        partner: {
-          name: 'Katie',
-          age: 110
+        {
+          object_type: 'HeadOfHousehold',
+          person: {
+            name: 'Matt',
+            age: 109
+          },
+          partner: {
+            name: 'Katie',
+            age: 110
+          }
         }
-      }
-    ]
+      ]
 
-    hydrated_objects = subject.array(objects)
+      hydrated_objects = subject.array(objects)
 
-    pet_obj = hydrated_objects.first
+      pet_obj = hydrated_objects.first
 
-    expect(pet_obj.name).to eq('Doug the dog')
-    expect(pet_obj.toy.squishy).to be true
+      expect(pet_obj.name).to eq('Doug the dog')
+      expect(pet_obj.toy.squishy).to be true
 
-    head_of_household_obj = hydrated_objects.last
+      head_of_household_obj = hydrated_objects.last
 
-    expect(head_of_household_obj.person.name).to eq('Matt')
-    expect(head_of_household_obj.person.age).to eq(109)
-    expect(head_of_household_obj.partner.name).to eq('Katie')
-    expect(head_of_household_obj.partner.age).to eq(110)
+      expect(head_of_household_obj.person.name).to eq('Matt')
+      expect(head_of_household_obj.person.age).to eq(109)
+      expect(head_of_household_obj.partner.name).to eq('Katie')
+      expect(head_of_household_obj.partner.age).to eq(110)
+    end
   end
 end


### PR DESCRIPTION
There is a need to have hashable factories leverage Rails autoloader: when a reloadable class is updated, Rail's will unload and reload the constant, thus making the old Hashable references stale.  In this case Rails will raise an error similar to [this](https://stackoverflow.com/questions/29636334/a-copy-of-xxx-has-been-removed-from-the-module-tree-but-is-still-active).

In order to incorporate auto-reloading, this PR adds the ability to register strings, which will be properly reloaded within a Rails application (and most likely any similar autoloading environments.)